### PR TITLE
Feat: added disableResize prop

### DIFF
--- a/src/TagCloud.tsx
+++ b/src/TagCloud.tsx
@@ -23,6 +23,7 @@ interface ITagCloudProps {
     | "rectangular"
     | ((size: number) => (t: number) => [number, number]);
   random?: () => number;
+  disableResize: boolean;
 }
 
 interface ITagCloudState {
@@ -53,6 +54,7 @@ class TagCloud extends React.Component<ITagCloudProps, ITagCloudState> {
       ]),
       padding: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
     }),
+    disableResize: PropTypes.bool,
   };
 
   public static defaultProps = {
@@ -66,6 +68,7 @@ class TagCloud extends React.Component<ITagCloudProps, ITagCloudState> {
       fontWeight: "normal",
       padding: 1,
     },
+    disableResize: false,
   };
   public state = {
     children: undefined,
@@ -257,6 +260,10 @@ class TagCloud extends React.Component<ITagCloudProps, ITagCloudState> {
           height,
           width,
         });
+        return;
+      }
+
+      if (this.props.disableResize) {
         return;
       }
 


### PR DESCRIPTION
Thanks for the lib, this works well!

This PR adds an optional `disableResize` prop.

Reason being:  while using this lib on a project, `onResize` is being triggered mid-animation and  `contentRect.bounds` has the wrong values, so the component gets rendered incorrectly.
(line: https://github.com/IjzerenHein/react-tag-cloud/blob/master/src/TagCloud.tsx#L252)

`disableResize` enables users to opt out of the existing behaviour

(We can implement this in a different way if you want to discuss it)

Thanks