### PR TITLE
add optional `className` prop

### DIFF
--- a/src/TagCloud.tsx
+++ b/src/TagCloud.tsx
@@ -6,6 +6,7 @@ import Measure from "react-measure";
 
 interface ITagCloudProps {
   children: any;
+  className?: string;
   style: {
     fontFamily?: string | ((word: any, index: number) => string);
     fontStyle?: string | ((word: any, index: number) => string);


### PR DESCRIPTION
🐛 bug fix.

I was using your tag cloud for a portfolio website. I was using TypeScript and there was an error in which `TagCloud` did not accept `className`  prop. I fixed it by including it in the Props interface.

Please merge. Thanks!